### PR TITLE
CodeMirror: autocomplete - more suggestions

### DIFF
--- a/src/components/codemirror/hint.js
+++ b/src/components/codemirror/hint.js
@@ -155,6 +155,31 @@ const hint = (cm, options) => {
     }
   }
 
+  if (normalize(currentLine).indexOf('git merge') === 0) {
+    const candidates = [];
+    logManager.getMergeableBranches()
+      .filter((branch) => {
+        return branch !== logManager.getCurrentBranch();
+      })
+      .forEach((branch) => {
+        candidates.push(sprintf('git merge %s', branch));
+      });
+
+    const list = candidates.filter((item) => {
+      const normalized = normalize(currentLine);
+
+      return (item.indexOf(normalized) === 0) && (normalized !== item);
+    });
+
+    if (list.length > 0) {
+      return {
+        list: list,
+        from: CodeMirror.Pos(cursor.line, currentLine.indexOf('git')),
+        to: CodeMirror.Pos(cursor.line, currentLine.length),
+      };
+    }
+  }
+
   return null;
 };
 

--- a/src/components/codemirror/hint.js
+++ b/src/components/codemirror/hint.js
@@ -84,6 +84,32 @@ const hint = (cm, options) => {
     };
   }
 
+  if (normalize(currentLine).indexOf('git checkout') === 0) {
+    const candidates = [];
+    candidates.push('git checkout -b ');
+    logManager.getCreatedBranches()
+      .filter((branch) => {
+        return branch !== logManager.getCurrentBranch();
+      })
+      .forEach((branch) => {
+        candidates.push(sprintf('git checkout %s', branch));
+      });
+
+    const list = candidates.filter((item) => {
+      const normalized = normalize(currentLine);
+
+      return (item.indexOf(normalized) === 0) && (normalized !== item);
+    });
+
+    if (list.length > 0) {
+      return {
+        list: list,
+        from: CodeMirror.Pos(cursor.line, currentLine.indexOf('git')),
+        to: CodeMirror.Pos(cursor.line, currentLine.length),
+      };
+    }
+  }
+
   return null;
 };
 

--- a/src/components/codemirror/hint.js
+++ b/src/components/codemirror/hint.js
@@ -154,7 +154,7 @@ const hint = (cm, options) => {
  * @returns {string}
  */
 const normalize = (value) => {
-  return value.trim().split(/\s+/).join(' ');
+  return value.trimStart().split(/\s+/).join(' ');
 };
 
 /**

--- a/src/components/codemirror/hint.js
+++ b/src/components/codemirror/hint.js
@@ -22,8 +22,9 @@ const hint = (cm, options) => {
   } catch (e) {}
 
   const line = cm.getLine(cursor.line);
+  const lineNormalized = normalize(line);
 
-  if (normalize(line).length === 0) {
+  if (lineNormalized.length === 0) {
     return null;
   }
 
@@ -37,10 +38,9 @@ const hint = (cm, options) => {
   ];
 
   const gitCommandSuggestions = gitCommands.filter((command) => {
-    const normalized = normalize(line);
     const trimmed = command.trim();
 
-    return (trimmed.indexOf(normalized) === 0) && (normalized !== trimmed);
+    return (trimmed.indexOf(lineNormalized) === 0) && (lineNormalized !== trimmed);
   });
 
   if (gitCommandSuggestions.length > 0) {
@@ -51,7 +51,7 @@ const hint = (cm, options) => {
     };
   }
 
-  if (normalize(line) === 'git commit' && endsWithSpace(line)) {
+  if (lineNormalized === 'git commit' && endsWithSpace(line)) {
     return {
       list: ['-m '],
       from: CodeMirror.Pos(cursor.line, line.length),
@@ -59,7 +59,7 @@ const hint = (cm, options) => {
     }
   }
 
-  if (normalize(line) === 'git checkout' && endsWithSpace(line)) {
+  if (lineNormalized === 'git checkout' && endsWithSpace(line)) {
     return {
       list: logManager.getOtherBranches().concat(['-b ']),
       from: CodeMirror.Pos(cursor.line, line.length),
@@ -67,7 +67,7 @@ const hint = (cm, options) => {
     };
   }
 
-  if (normalize(line) === 'git switch' && endsWithSpace(line)) {
+  if (lineNormalized === 'git switch' && endsWithSpace(line)) {
     return {
       list: logManager.getOtherBranches().concat(['-c ']),
       from: CodeMirror.Pos(cursor.line, line.length),
@@ -75,7 +75,7 @@ const hint = (cm, options) => {
     };
   }
 
-  if (normalize(line) === 'git merge' && endsWithSpace(line)) {
+  if (lineNormalized === 'git merge' && endsWithSpace(line)) {
     return {
       list: logManager.getMergeableBranches(),
       from: CodeMirror.Pos(cursor.line, line.length),
@@ -83,11 +83,10 @@ const hint = (cm, options) => {
     };
   }
 
-  if (normalize(line).indexOf('git commit -') === 0) {
+  if (lineNormalized.indexOf('git commit -') === 0) {
     const list = ['git commit -m ']
       .filter((item) => {
-        const normalized = normalize(line);
-        return (item.indexOf(normalized) === 0) && (normalized !== normalize(item));
+        return (item.indexOf(lineNormalized) === 0) && (lineNormalized !== normalize(item));
       });
 
     if (list.length > 0) {
@@ -99,13 +98,12 @@ const hint = (cm, options) => {
     }
   }
 
-  if (normalize(line).indexOf('git checkout') === 0) {
+  if (lineNormalized.indexOf('git checkout') === 0) {
     const list = logManager.getOtherBranches()
       .map(branch => sprintf('git checkout %s', branch))
       .concat(['git checkout -b '])
       .filter((item) => {
-        const normalized = normalize(line);
-        return (item.indexOf(normalized) === 0) && (normalized !== item);
+        return (item.indexOf(lineNormalized) === 0) && (lineNormalized !== item);
       });
 
     if (list.length > 0) {
@@ -117,13 +115,12 @@ const hint = (cm, options) => {
     }
   }
 
-  if (normalize(line).indexOf('git switch') === 0) {
+  if (lineNormalized.indexOf('git switch') === 0) {
     const list = logManager.getOtherBranches()
       .map(branch => sprintf('git switch %s', branch))
       .concat(['git switch -c '])
       .filter((item) => {
-        const normalized = normalize(line);
-        return (item.indexOf(normalized) === 0) && (normalized !== item);
+        return (item.indexOf(lineNormalized) === 0) && (lineNormalized !== item);
       });
 
     if (list.length > 0) {
@@ -135,12 +132,11 @@ const hint = (cm, options) => {
     }
   }
 
-  if (normalize(line).indexOf('git merge') === 0) {
+  if (lineNormalized.indexOf('git merge') === 0) {
     const list = logManager.getMergeableBranches()
       .map(branch => sprintf('git merge %s', branch))
       .filter((item) => {
-        const normalized = normalize(line);
-        return (item.indexOf(normalized) === 0) && (normalized !== item);
+        return (item.indexOf(lineNormalized) === 0) && (lineNormalized !== item);
       });
 
     if (list.length > 0) {

--- a/src/components/codemirror/hint.js
+++ b/src/components/codemirror/hint.js
@@ -28,25 +28,25 @@ const hint = (cm, options) => {
     return null;
   }
 
-  const gitCommands = [
-    'git commit',
-    'git branch ',
-    'git checkout ',
-    'git switch ',
-    'git merge ',
-    'git tag ',
-  ];
+  if (lineNormalized.indexOf('g') === 0) {
+    const list = []
+      .concat(['git commit'])
+      .concat(['git branch '])
+      .concat(['git checkout '])
+      .concat(['git switch '])
+      .concat(['git merge '])
+      .concat(['git tag '])
+      .filter((item) => {
+        return (item.indexOf(lineNormalized) === 0) && (lineNormalized !== item.trim());
+      });
 
-  const gitCommandSuggestions = gitCommands.filter((command) => {
-    return (command.indexOf(lineNormalized) === 0) && (lineNormalized !== command.trim());
-  });
-
-  if (gitCommandSuggestions.length > 0) {
-    return {
-      list: gitCommandSuggestions,
-      from: CodeMirror.Pos(cursor.line, line.indexOf('git')),
-      to: CodeMirror.Pos(cursor.line, line.length),
-    };
+    if (list.length > 0) {
+      return {
+        list: list,
+        from: CodeMirror.Pos(cursor.line, line.indexOf('git')),
+        to: CodeMirror.Pos(cursor.line, line.length),
+      };
+    }
   }
 
   if (lineNormalized === 'git commit' && endsWithSpace(line)) {

--- a/src/components/codemirror/hint.js
+++ b/src/components/codemirror/hint.js
@@ -28,119 +28,77 @@ const hint = (cm, options) => {
     return null;
   }
 
-  if (lineNormalized.indexOf('g') === 0) {
+  if (lineNormalized.indexOf('git ') === 0) {
     const list = []
-      .concat(['git commit'])
-      .concat(['git branch '])
-      .concat(['git checkout '])
-      .concat(['git switch '])
-      .concat(['git merge '])
-      .concat(['git tag '])
-      .filter((item) => {
-        return (item.indexOf(lineNormalized) === 0) && (lineNormalized !== item.trim());
-      });
+      .concat(['commit'])
+      .concat(['branch '])
+      .concat(['checkout '])
+      .concat(['switch '])
+      .concat(['merge '])
+      .concat(['tag '])
+      .filter(item => sprintf('git %s', item).indexOf(lineNormalized) === 0)
+      .filter(item => sprintf('git %s', item) !== lineNormalized);
 
     if (list.length > 0) {
       return {
         list: list,
-        from: CodeMirror.Pos(cursor.line, line.indexOf('git')),
+        from: CodeMirror.Pos(cursor.line, 'git '.length),
         to: CodeMirror.Pos(cursor.line, line.length),
       };
     }
   }
 
-  if (lineNormalized === 'git commit' && endsWithSpace(line)) {
-    return {
-      list: ['-m '],
-      from: CodeMirror.Pos(cursor.line, line.length),
-      to: CodeMirror.Pos(cursor.line, line.length),
-    }
-  }
-
-  if (lineNormalized === 'git checkout' && endsWithSpace(line)) {
-    return {
-      list: logManager.getOtherBranches().concat(['-b ']),
-      from: CodeMirror.Pos(cursor.line, line.length),
-      to: CodeMirror.Pos(cursor.line, line.length),
-    };
-  }
-
-  if (lineNormalized === 'git switch' && endsWithSpace(line)) {
-    return {
-      list: logManager.getOtherBranches().concat(['-c ']),
-      from: CodeMirror.Pos(cursor.line, line.length),
-      to: CodeMirror.Pos(cursor.line, line.length),
-    };
-  }
-
-  if (lineNormalized === 'git merge' && endsWithSpace(line)) {
-    return {
-      list: logManager.getMergeableBranches(),
-      from: CodeMirror.Pos(cursor.line, line.length),
-      to: CodeMirror.Pos(cursor.line, line.length),
-    };
-  }
-
-  if (lineNormalized.indexOf('git commit -') === 0) {
-    const list = ['git commit -m ']
-      .filter((item) => {
-        return (item.indexOf(lineNormalized) === 0) && (lineNormalized !== item.trim());
-      });
+  if (lineNormalized.indexOf('git commit ') === 0) {
+    const list = ['-m ']
+      .filter(item => sprintf('git commit %s', item).indexOf(lineNormalized) === 0)
+      .filter(item => sprintf('git commit %s', item) !== lineNormalized);
 
     if (list.length > 0) {
       return {
         list: list,
-        from: CodeMirror.Pos(cursor.line, line.indexOf('git')),
+        from: CodeMirror.Pos(cursor.line, 'git commit '.length),
         to: CodeMirror.Pos(cursor.line, line.length),
       };
     }
   }
 
-  if (lineNormalized.indexOf('git checkout') === 0) {
-    const list = logManager.getOtherBranches()
-      .map(branch => sprintf('git checkout %s', branch))
-      .concat(['git checkout -b '])
-      .filter((item) => {
-        return (item.indexOf(lineNormalized) === 0) && (lineNormalized !== item.trim());
-      });
+  if (lineNormalized.indexOf('git checkout ') === 0) {
+    const list = logManager.getOtherBranches().concat(['-b '])
+      .filter(item => sprintf('git checkout %s', item).indexOf(lineNormalized) === 0)
+      .filter(item => sprintf('git checkout %s', item) !== lineNormalized);
 
     if (list.length > 0) {
       return {
         list: list,
-        from: CodeMirror.Pos(cursor.line, line.indexOf('git')),
+        from: CodeMirror.Pos(cursor.line, 'git checkout '.length),
         to: CodeMirror.Pos(cursor.line, line.length),
       };
     }
   }
 
-  if (lineNormalized.indexOf('git switch') === 0) {
-    const list = logManager.getOtherBranches()
-      .map(branch => sprintf('git switch %s', branch))
-      .concat(['git switch -c '])
-      .filter((item) => {
-        return (item.indexOf(lineNormalized) === 0) && (lineNormalized !== item.trim());
-      });
+  if (lineNormalized.indexOf('git switch ') === 0) {
+    const list = logManager.getOtherBranches().concat(['-c '])
+      .filter(item => sprintf('git switch %s', item).indexOf(lineNormalized) === 0)
+      .filter(item => sprintf('git switch %s', item) !== lineNormalized);
 
     if (list.length > 0) {
       return {
         list: list,
-        from: CodeMirror.Pos(cursor.line, line.indexOf('git')),
+        from: CodeMirror.Pos(cursor.line, 'git switch '.length),
         to: CodeMirror.Pos(cursor.line, line.length),
       };
     }
   }
 
-  if (lineNormalized.indexOf('git merge') === 0) {
+  if (lineNormalized.indexOf('git merge ') === 0) {
     const list = logManager.getMergeableBranches()
-      .map(branch => sprintf('git merge %s', branch))
-      .filter((item) => {
-        return (item.indexOf(lineNormalized) === 0) && (lineNormalized !== item.trim());
-      });
+      .filter(item => sprintf('git merge %s', item).indexOf(lineNormalized) === 0)
+      .filter(item => sprintf('git merge %s', item) !== lineNormalized);
 
     if (list.length > 0) {
       return {
         list: list,
-        from: CodeMirror.Pos(cursor.line, line.indexOf('git')),
+        from: CodeMirror.Pos(cursor.line, 'git merge '.length),
         to: CodeMirror.Pos(cursor.line, line.length),
       };
     }

--- a/src/components/codemirror/hint.js
+++ b/src/components/codemirror/hint.js
@@ -23,6 +23,10 @@ const hint = (cm, options) => {
 
   const currentLine = cm.getLine(cursor.line);
 
+  if (normalize(currentLine).length === 0) {
+    return null;
+  }
+
   const gitCommands = [
     'git commit',
     'git branch ',
@@ -36,7 +40,7 @@ const hint = (cm, options) => {
     const normalized = normalize(currentLine);
     const trimmed = command.trim();
 
-    return (normalized.length > 0) && (trimmed.indexOf(normalized) === 0) && (normalized !== trimmed);
+    return (trimmed.indexOf(normalized) === 0) && (normalized !== trimmed);
   });
 
   if (gitCommandSuggestions.length > 0) {

--- a/src/components/codemirror/hint.js
+++ b/src/components/codemirror/hint.js
@@ -84,14 +84,11 @@ const hint = (cm, options) => {
   }
 
   if (normalize(currentLine).indexOf('git commit -') === 0) {
-    const candidates = [];
-    candidates.push('git commit -m ');
-
-    const list = candidates.filter((item) => {
-      const normalized = normalize(currentLine);
-
-      return (item.indexOf(normalized) === 0) && (normalized !== normalize(item));
-    });
+    const list = ['git commit -m ']
+      .filter((item) => {
+        const normalized = normalize(currentLine);
+        return (item.indexOf(normalized) === 0) && (normalized !== normalize(item));
+      });
 
     if (list.length > 0) {
       return {
@@ -103,15 +100,13 @@ const hint = (cm, options) => {
   }
 
   if (normalize(currentLine).indexOf('git checkout') === 0) {
-    const candidates = logManager.getOtherBranches()
+    const list = logManager.getOtherBranches()
       .map(branch => sprintf('git checkout %s', branch))
-      .concat(['git checkout -b ']);
-
-    const list = candidates.filter((item) => {
-      const normalized = normalize(currentLine);
-
-      return (item.indexOf(normalized) === 0) && (normalized !== item);
-    });
+      .concat(['git checkout -b '])
+      .filter((item) => {
+        const normalized = normalize(currentLine);
+        return (item.indexOf(normalized) === 0) && (normalized !== item);
+      });
 
     if (list.length > 0) {
       return {
@@ -123,15 +118,13 @@ const hint = (cm, options) => {
   }
 
   if (normalize(currentLine).indexOf('git switch') === 0) {
-    const candidates = logManager.getOtherBranches()
+    const list = logManager.getOtherBranches()
       .map(branch => sprintf('git switch %s', branch))
-      .concat(['git switch -c ']);
-
-    const list = candidates.filter((item) => {
-      const normalized = normalize(currentLine);
-
-      return (item.indexOf(normalized) === 0) && (normalized !== item);
-    });
+      .concat(['git switch -c '])
+      .filter((item) => {
+        const normalized = normalize(currentLine);
+        return (item.indexOf(normalized) === 0) && (normalized !== item);
+      });
 
     if (list.length > 0) {
       return {
@@ -143,14 +136,12 @@ const hint = (cm, options) => {
   }
 
   if (normalize(currentLine).indexOf('git merge') === 0) {
-    const candidates = logManager.getMergeableBranches()
-      .map(branch => sprintf('git merge %s', branch));
-
-    const list = candidates.filter((item) => {
-      const normalized = normalize(currentLine);
-
-      return (item.indexOf(normalized) === 0) && (normalized !== item);
-    });
+    const list = logManager.getMergeableBranches()
+      .map(branch => sprintf('git merge %s', branch))
+      .filter((item) => {
+        const normalized = normalize(currentLine);
+        return (item.indexOf(normalized) === 0) && (normalized !== item);
+      });
 
     if (list.length > 0) {
       return {

--- a/src/components/codemirror/hint.js
+++ b/src/components/codemirror/hint.js
@@ -38,9 +38,7 @@ const hint = (cm, options) => {
   ];
 
   const gitCommandSuggestions = gitCommands.filter((command) => {
-    const trimmed = command.trim();
-
-    return (trimmed.indexOf(lineNormalized) === 0) && (lineNormalized !== trimmed);
+    return (command.indexOf(lineNormalized) === 0) && (lineNormalized !== command.trim());
   });
 
   if (gitCommandSuggestions.length > 0) {
@@ -86,7 +84,7 @@ const hint = (cm, options) => {
   if (lineNormalized.indexOf('git commit -') === 0) {
     const list = ['git commit -m ']
       .filter((item) => {
-        return (item.indexOf(lineNormalized) === 0) && (lineNormalized !== normalize(item));
+        return (item.indexOf(lineNormalized) === 0) && (lineNormalized !== item.trim());
       });
 
     if (list.length > 0) {
@@ -103,7 +101,7 @@ const hint = (cm, options) => {
       .map(branch => sprintf('git checkout %s', branch))
       .concat(['git checkout -b '])
       .filter((item) => {
-        return (item.indexOf(lineNormalized) === 0) && (lineNormalized !== item);
+        return (item.indexOf(lineNormalized) === 0) && (lineNormalized !== item.trim());
       });
 
     if (list.length > 0) {
@@ -120,7 +118,7 @@ const hint = (cm, options) => {
       .map(branch => sprintf('git switch %s', branch))
       .concat(['git switch -c '])
       .filter((item) => {
-        return (item.indexOf(lineNormalized) === 0) && (lineNormalized !== item);
+        return (item.indexOf(lineNormalized) === 0) && (lineNormalized !== item.trim());
       });
 
     if (list.length > 0) {
@@ -136,7 +134,7 @@ const hint = (cm, options) => {
     const list = logManager.getMergeableBranches()
       .map(branch => sprintf('git merge %s', branch))
       .filter((item) => {
-        return (item.indexOf(lineNormalized) === 0) && (lineNormalized !== item);
+        return (item.indexOf(lineNormalized) === 0) && (lineNormalized !== item.trim());
       });
 
     if (list.length > 0) {

--- a/src/components/codemirror/hint.js
+++ b/src/components/codemirror/hint.js
@@ -84,6 +84,25 @@ const hint = (cm, options) => {
     };
   }
 
+  if (normalize(currentLine).indexOf('git commit') === 0) {
+    const candidates = [];
+    candidates.push('git commit -m ');
+
+    const list = candidates.filter((item) => {
+      const normalized = normalize(currentLine);
+
+      return (item.indexOf(normalized) === 0) && (normalized !== item);
+    });
+
+    if (list.length > 0) {
+      return {
+        list: list,
+        from: CodeMirror.Pos(cursor.line, currentLine.indexOf('git')),
+        to: CodeMirror.Pos(cursor.line, currentLine.length),
+      };
+    }
+  }
+
   if (normalize(currentLine).indexOf('git checkout') === 0) {
     const candidates = [];
     candidates.push('git checkout -b ');

--- a/src/components/codemirror/hint.js
+++ b/src/components/codemirror/hint.js
@@ -57,9 +57,7 @@ const hint = (cm, options) => {
 
   if (normalize(currentLine) === 'git checkout' && endsWithSpace(currentLine)) {
     return {
-      list: logManager.getCreatedBranches().filter((branch) => {
-        return branch !== logManager.getCurrentBranch();
-      }).concat(['-b ']),
+      list: logManager.getOtherBranches().concat(['-b ']),
       from: CodeMirror.Pos(cursor.line, currentLine.length),
       to: CodeMirror.Pos(cursor.line, currentLine.length),
     };
@@ -67,9 +65,7 @@ const hint = (cm, options) => {
 
   if (normalize(currentLine) === 'git switch' && endsWithSpace(currentLine)) {
     return {
-      list: logManager.getCreatedBranches().filter((branch) => {
-        return branch !== logManager.getCurrentBranch();
-      }).concat(['-c ']),
+      list: logManager.getOtherBranches().concat(['-c ']),
       from: CodeMirror.Pos(cursor.line, currentLine.length),
       to: CodeMirror.Pos(cursor.line, currentLine.length),
     };
@@ -77,9 +73,7 @@ const hint = (cm, options) => {
 
   if (normalize(currentLine) === 'git merge' && endsWithSpace(currentLine)) {
     return {
-      list: logManager.getMergeableBranches().filter((branch) => {
-        return branch !== logManager.getCurrentBranch();
-      }),
+      list: logManager.getMergeableBranches(),
       from: CodeMirror.Pos(cursor.line, currentLine.length),
       to: CodeMirror.Pos(cursor.line, currentLine.length),
     };
@@ -105,15 +99,9 @@ const hint = (cm, options) => {
   }
 
   if (normalize(currentLine).indexOf('git checkout') === 0) {
-    const candidates = [];
-    candidates.push('git checkout -b ');
-    logManager.getCreatedBranches()
-      .filter((branch) => {
-        return branch !== logManager.getCurrentBranch();
-      })
-      .forEach((branch) => {
-        candidates.push(sprintf('git checkout %s', branch));
-      });
+    const candidates = logManager.getOtherBranches()
+      .map(branch => sprintf('git checkout %s', branch))
+      .concat(['git checkout -b ']);
 
     const list = candidates.filter((item) => {
       const normalized = normalize(currentLine);
@@ -131,15 +119,9 @@ const hint = (cm, options) => {
   }
 
   if (normalize(currentLine).indexOf('git switch') === 0) {
-    const candidates = [];
-    candidates.push('git switch -c ');
-    logManager.getCreatedBranches()
-      .filter((branch) => {
-        return branch !== logManager.getCurrentBranch();
-      })
-      .forEach((branch) => {
-        candidates.push(sprintf('git switch %s', branch));
-      });
+    const candidates = logManager.getOtherBranches()
+      .map(branch => sprintf('git switch %s', branch))
+      .concat(['git switch -c ']);
 
     const list = candidates.filter((item) => {
       const normalized = normalize(currentLine);
@@ -157,14 +139,8 @@ const hint = (cm, options) => {
   }
 
   if (normalize(currentLine).indexOf('git merge') === 0) {
-    const candidates = [];
-    logManager.getMergeableBranches()
-      .filter((branch) => {
-        return branch !== logManager.getCurrentBranch();
-      })
-      .forEach((branch) => {
-        candidates.push(sprintf('git merge %s', branch));
-      });
+    const candidates = logManager.getMergeableBranches()
+      .map(branch => sprintf('git merge %s', branch));
 
     const list = candidates.filter((item) => {
       const normalized = normalize(currentLine);

--- a/src/components/codemirror/hint.js
+++ b/src/components/codemirror/hint.js
@@ -85,14 +85,14 @@ const hint = (cm, options) => {
     };
   }
 
-  if (normalize(currentLine).indexOf('git commit') === 0) {
+  if (normalize(currentLine).indexOf('git commit -') === 0) {
     const candidates = [];
     candidates.push('git commit -m ');
 
     const list = candidates.filter((item) => {
       const normalized = normalize(currentLine);
 
-      return (item.indexOf(normalized) === 0) && (normalized !== item);
+      return (item.indexOf(normalized) === 0) && (normalized !== normalize(item));
     });
 
     if (list.length > 0) {

--- a/src/components/codemirror/hint.js
+++ b/src/components/codemirror/hint.js
@@ -110,6 +110,32 @@ const hint = (cm, options) => {
     }
   }
 
+  if (normalize(currentLine).indexOf('git switch') === 0) {
+    const candidates = [];
+    candidates.push('git switch -c ');
+    logManager.getCreatedBranches()
+      .filter((branch) => {
+        return branch !== logManager.getCurrentBranch();
+      })
+      .forEach((branch) => {
+        candidates.push(sprintf('git switch %s', branch));
+      });
+
+    const list = candidates.filter((item) => {
+      const normalized = normalize(currentLine);
+
+      return (item.indexOf(normalized) === 0) && (normalized !== item);
+    });
+
+    if (list.length > 0) {
+      return {
+        list: list,
+        from: CodeMirror.Pos(cursor.line, currentLine.indexOf('git')),
+        to: CodeMirror.Pos(cursor.line, currentLine.length),
+      };
+    }
+  }
+
   return null;
 };
 

--- a/src/components/codemirror/hint.js
+++ b/src/components/codemirror/hint.js
@@ -25,6 +25,7 @@ const hint = (cm, options) => {
 
   const gitCommands = [
     'git commit',
+    'git branch ',
     'git checkout ',
     'git switch ',
     'git merge ',

--- a/src/components/codemirror/hint.js
+++ b/src/components/codemirror/hint.js
@@ -21,9 +21,9 @@ const hint = (cm, options) => {
     });
   } catch (e) {}
 
-  const currentLine = cm.getLine(cursor.line);
+  const line = cm.getLine(cursor.line);
 
-  if (normalize(currentLine).length === 0) {
+  if (normalize(line).length === 0) {
     return null;
   }
 
@@ -37,7 +37,7 @@ const hint = (cm, options) => {
   ];
 
   const gitCommandSuggestions = gitCommands.filter((command) => {
-    const normalized = normalize(currentLine);
+    const normalized = normalize(line);
     const trimmed = command.trim();
 
     return (trimmed.indexOf(normalized) === 0) && (normalized !== trimmed);
@@ -46,108 +46,108 @@ const hint = (cm, options) => {
   if (gitCommandSuggestions.length > 0) {
     return {
       list: gitCommandSuggestions,
-      from: CodeMirror.Pos(cursor.line, currentLine.indexOf('git')),
-      to: CodeMirror.Pos(cursor.line, currentLine.length),
+      from: CodeMirror.Pos(cursor.line, line.indexOf('git')),
+      to: CodeMirror.Pos(cursor.line, line.length),
     };
   }
 
-  if (normalize(currentLine) === 'git commit' && endsWithSpace(currentLine)) {
+  if (normalize(line) === 'git commit' && endsWithSpace(line)) {
     return {
       list: ['-m '],
-      from: CodeMirror.Pos(cursor.line, currentLine.length),
-      to: CodeMirror.Pos(cursor.line, currentLine.length),
+      from: CodeMirror.Pos(cursor.line, line.length),
+      to: CodeMirror.Pos(cursor.line, line.length),
     }
   }
 
-  if (normalize(currentLine) === 'git checkout' && endsWithSpace(currentLine)) {
+  if (normalize(line) === 'git checkout' && endsWithSpace(line)) {
     return {
       list: logManager.getOtherBranches().concat(['-b ']),
-      from: CodeMirror.Pos(cursor.line, currentLine.length),
-      to: CodeMirror.Pos(cursor.line, currentLine.length),
+      from: CodeMirror.Pos(cursor.line, line.length),
+      to: CodeMirror.Pos(cursor.line, line.length),
     };
   }
 
-  if (normalize(currentLine) === 'git switch' && endsWithSpace(currentLine)) {
+  if (normalize(line) === 'git switch' && endsWithSpace(line)) {
     return {
       list: logManager.getOtherBranches().concat(['-c ']),
-      from: CodeMirror.Pos(cursor.line, currentLine.length),
-      to: CodeMirror.Pos(cursor.line, currentLine.length),
+      from: CodeMirror.Pos(cursor.line, line.length),
+      to: CodeMirror.Pos(cursor.line, line.length),
     };
   }
 
-  if (normalize(currentLine) === 'git merge' && endsWithSpace(currentLine)) {
+  if (normalize(line) === 'git merge' && endsWithSpace(line)) {
     return {
       list: logManager.getMergeableBranches(),
-      from: CodeMirror.Pos(cursor.line, currentLine.length),
-      to: CodeMirror.Pos(cursor.line, currentLine.length),
+      from: CodeMirror.Pos(cursor.line, line.length),
+      to: CodeMirror.Pos(cursor.line, line.length),
     };
   }
 
-  if (normalize(currentLine).indexOf('git commit -') === 0) {
+  if (normalize(line).indexOf('git commit -') === 0) {
     const list = ['git commit -m ']
       .filter((item) => {
-        const normalized = normalize(currentLine);
+        const normalized = normalize(line);
         return (item.indexOf(normalized) === 0) && (normalized !== normalize(item));
       });
 
     if (list.length > 0) {
       return {
         list: list,
-        from: CodeMirror.Pos(cursor.line, currentLine.indexOf('git')),
-        to: CodeMirror.Pos(cursor.line, currentLine.length),
+        from: CodeMirror.Pos(cursor.line, line.indexOf('git')),
+        to: CodeMirror.Pos(cursor.line, line.length),
       };
     }
   }
 
-  if (normalize(currentLine).indexOf('git checkout') === 0) {
+  if (normalize(line).indexOf('git checkout') === 0) {
     const list = logManager.getOtherBranches()
       .map(branch => sprintf('git checkout %s', branch))
       .concat(['git checkout -b '])
       .filter((item) => {
-        const normalized = normalize(currentLine);
+        const normalized = normalize(line);
         return (item.indexOf(normalized) === 0) && (normalized !== item);
       });
 
     if (list.length > 0) {
       return {
         list: list,
-        from: CodeMirror.Pos(cursor.line, currentLine.indexOf('git')),
-        to: CodeMirror.Pos(cursor.line, currentLine.length),
+        from: CodeMirror.Pos(cursor.line, line.indexOf('git')),
+        to: CodeMirror.Pos(cursor.line, line.length),
       };
     }
   }
 
-  if (normalize(currentLine).indexOf('git switch') === 0) {
+  if (normalize(line).indexOf('git switch') === 0) {
     const list = logManager.getOtherBranches()
       .map(branch => sprintf('git switch %s', branch))
       .concat(['git switch -c '])
       .filter((item) => {
-        const normalized = normalize(currentLine);
+        const normalized = normalize(line);
         return (item.indexOf(normalized) === 0) && (normalized !== item);
       });
 
     if (list.length > 0) {
       return {
         list: list,
-        from: CodeMirror.Pos(cursor.line, currentLine.indexOf('git')),
-        to: CodeMirror.Pos(cursor.line, currentLine.length),
+        from: CodeMirror.Pos(cursor.line, line.indexOf('git')),
+        to: CodeMirror.Pos(cursor.line, line.length),
       };
     }
   }
 
-  if (normalize(currentLine).indexOf('git merge') === 0) {
+  if (normalize(line).indexOf('git merge') === 0) {
     const list = logManager.getMergeableBranches()
       .map(branch => sprintf('git merge %s', branch))
       .filter((item) => {
-        const normalized = normalize(currentLine);
+        const normalized = normalize(line);
         return (item.indexOf(normalized) === 0) && (normalized !== item);
       });
 
     if (list.length > 0) {
       return {
         list: list,
-        from: CodeMirror.Pos(cursor.line, currentLine.indexOf('git')),
-        to: CodeMirror.Pos(cursor.line, currentLine.length),
+        from: CodeMirror.Pos(cursor.line, line.indexOf('git')),
+        to: CodeMirror.Pos(cursor.line, line.length),
       };
     }
   }

--- a/src/components/codemirror/log-manager.js
+++ b/src/components/codemirror/log-manager.js
@@ -6,32 +6,25 @@ class LogManager extends LogManagerOriginal {
   }
 
   /**
-   * @return {string}
-   */
-  getCurrentBranch() {
-    return this._getCurrentBranch();
-  }
-
-  /**
+   * Get the branch names other than current branch.
+   *
    * @return {string[]}
    */
-  getCreatedBranches() {
-    return this._branchList.getBranchNames();
+  getOtherBranches() {
+    return this._branchList.getBranchNames().filter((branch) => {
+      return branch !== this._getCurrentBranch();
+    });
   }
 
   /**
+   * Get the branch names that can be merged into current branch.
+   *
    * @return {string[]}
    */
   getMergeableBranches() {
-    const result = [];
-
-    this.getCreatedBranches().forEach((branch) => {
-      if (this._branchList.get(branch).getCommitCount() > 0) {
-        result.push(branch);
-      }
+    return this.getOtherBranches().filter((branch) => {
+      return this._branchList.get(branch).getCommitCount() > 0;
     });
-
-    return result;
   }
 }
 


### PR DESCRIPTION
## Example

Current branch: `master`
Other branches: `b1` and `b2`

When current line is `git switch b`, suggest `git switch {b1, b2}` (where `{...}` is pulldown).