### PR TITLE
Fix style of GitgraphMinigramEditor.vue

### DIFF
--- a/src/components/GitgraphMinigramEditor.vue
+++ b/src/components/GitgraphMinigramEditor.vue
@@ -168,7 +168,7 @@ export default {
 
 <style lang="stylus">
 .theme-default-content {
-  max-width 100% !important
+  //max-width 100% !important
 }
 </style>
 

--- a/src/components/GitgraphMinigramEditor.vue
+++ b/src/components/GitgraphMinigramEditor.vue
@@ -100,6 +100,16 @@ export default {
   },
 
   mounted() {
+    // To change max-width, add class attribute.
+    // CSS for the class attribute is defined in <style>.
+    const contentElement = document.querySelector('.theme-default-content');
+    if (contentElement !== null) {
+      const existingClass = contentElement.getAttribute('class') || '';
+      const additionalClass = 'vuepress-plugin-gitgraph-minigram-editor-content';
+      const newAttribute = [existingClass, additionalClass].join(' ').trim();
+      contentElement.setAttribute('class', newAttribute);
+    }
+
     import('vue-codemirror').then((module) => {
       this.codemirrorComponent = module.codemirror;
     });
@@ -167,8 +177,8 @@ export default {
 </script>
 
 <style lang="stylus">
-.theme-default-content {
-  //max-width 100% !important
+.vuepress-plugin-gitgraph-minigram-editor-content {
+  max-width 100% !important
 }
 </style>
 


### PR DESCRIPTION
`max-width` style affects all pages.

```css
<style lang="stylus">
.theme-default-content {
  max-width 100% !important
}
</style>
```